### PR TITLE
travis file for CI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,8 @@ Session.vim
 *~
 # auto-generated tag files
 tags
+
+# Dependencies from microsoft/terraform-test Docker image
+Gemfile
+Rakefile
+build/

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,15 @@
+sudo: true
+dist: trusty
+language: ruby
+rvm:
+  - 2.3
+
+services:
+  - docker
+
+jobs:
+  include:
+    - stage: rake build
+      install: true
+      script:
+      - docker run -v $PWD:/tf-test/module --rm microsoft/terraform-test rake -f ../Rakefile build


### PR DESCRIPTION
Uses https://hub.docker.com/r/microsoft/terraform-test/ as the foundation for doing Travis CI testing.