### PR TITLE
Remove unused variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,10 @@ Usage
 Public loadbalancer example:
 
 ```hcl
+variable "resource_group_name" {
+  default = "my-terraform-lb"
+}
+
 variable "location" {
   default = "eastus"
 }

--- a/main.tf
+++ b/main.tf
@@ -42,7 +42,6 @@ resource "azurerm_lb_nat_rule" "azlb" {
   frontend_port                  = "5000${count.index + 1}"
   backend_port                   = "${element(var.remote_port["${element(keys(var.remote_port), count.index)}"], 1)}"
   frontend_ip_configuration_name = "${var.frontend_name}"
-  count                          = "${var.number_of_endpoints}"
 }
 
 resource "azurerm_lb_probe" "azlb" {

--- a/outputs.tf
+++ b/outputs.tf
@@ -8,11 +8,6 @@ output "azurerm_resource_group_name" {
   value       = "${azurerm_resource_group.azlb.name}"
 }
 
-output "number_of_nodes" {
-  description = "the number of load balancer nodes provisioned"
-  value       = "${var.number_of_endpoints}"
-}
-
 output "azurerm_lb_id" {
   description = "the id for the azurerm_lb resource"
   value       = "${azurerm_lb.azlb.id}"

--- a/variables.tf
+++ b/variables.tf
@@ -12,11 +12,6 @@ variable "prefix" {
   default     = "azure_lb"
 }
 
-variable "number_of_endpoints" {
-  description = "Number of inbound remote access rules to create which are load balanced on the vnet"
-  default     = 2
-}
-
 variable "remote_port" {
   description = "Protocols to be used for remote vm access. [protocol, backend_port].  Frontend port will be automatically generated starting at 50000 and in the output."
   default     = {}


### PR DESCRIPTION
We don't use this variable since we use the `"${length(var.remote_port)}"` on line 37 for count.
Also fixes a problem with the public example in the readme.