### PR TITLE
DEPRECATED "resource_group_name" field

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -31,7 +31,6 @@ resource "azurerm_lb" "azlb" {
 
 resource "azurerm_lb_backend_address_pool" "azlb" {
   name                = "BackEndAddressPool"
-  resource_group_name = data.azurerm_resource_group.azlb.name
   loadbalancer_id     = azurerm_lb.azlb.id
 }
 


### PR DESCRIPTION
Changes proposed in the pull request:
This code resolve warning in terraform in resource azurerm_lb_backend_address_pool
 
Warning: "resource_group_name": [DEPRECATED] This field is no longer used and will be removed in the next major version of the Azure Provider

  on .terraform/modules/module.lb/main.tf line 32, in resource "azurerm_lb_backend_address_pool" "azlb":
  32: resource "azurerm_lb_backend_address_pool" "azlb" {

The field "resource_group_name" is no longer in terraform documentation https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/lb_backend_address_pool


