### PR TITLE
Added new input variable 'name'

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ resource "azurerm_resource_group" "example" {
 module "mylb" {
   source              = "Azure/loadbalancer/azurerm"
   resource_group_name = azurerm_resource_group.example.name
-  prefix              = "terraform-test"
+  name                = "lb-terraform-test"
 
   remote_port = {
     ssh = ["Tcp", "22"]

--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ module "mylb" {
   source              = "Azure/loadbalancer/azurerm"
   resource_group_name = azurerm_resource_group.example.name
   name                = "lb-terraform-test"
+  pip_name            = "pip-terraform-test"
 
   remote_port = {
     ssh = ["Tcp", "22"]

--- a/main.tf
+++ b/main.tf
@@ -5,7 +5,7 @@ data "azurerm_resource_group" "azlb" {
 
 locals {
   lb_name  = var.name != "" ? var.name : format("%s-lb", var.prefix)
-  pip_name = var.name != "" ? format("pip-%s", var.name) : format("%s-publicIP", var.prefix)
+  pip_name = var.pip_name != "" ? var.pip_name : format("%s-publicIP", var.prefix)
 }
 
 resource "azurerm_public_ip" "azlb" {

--- a/test/fixture/main.tf
+++ b/test/fixture/main.tf
@@ -20,6 +20,7 @@ module "mylb" {
   frontend_private_ip_address            = "10.0.1.6"
   lb_sku                                 = "Standard"
   pip_sku                                = "Standard"
+  name                                   = "azure_lb"
 
   remote_port = {
     ssh = ["Tcp", "22"]

--- a/test/fixture/main.tf
+++ b/test/fixture/main.tf
@@ -21,7 +21,7 @@ module "mylb" {
   lb_sku                                 = "Standard"
   pip_sku                                = "Standard"
   name                                   = "lb-aztest"
-  pip_name                               = "pip-aztest
+  pip_name                               = "pip-aztest"
 
   remote_port = {
     ssh = ["Tcp", "22"]

--- a/test/fixture/main.tf
+++ b/test/fixture/main.tf
@@ -20,7 +20,8 @@ module "mylb" {
   frontend_private_ip_address            = "10.0.1.6"
   lb_sku                                 = "Standard"
   pip_sku                                = "Standard"
-  name                                   = "azure_lb"
+  name                                   = "lb-aztest"
+  pip_name                               = "pip-aztest
 
   remote_port = {
     ssh = ["Tcp", "22"]

--- a/variables.tf
+++ b/variables.tf
@@ -106,3 +106,9 @@ variable "name" {
   type        = string
   default     = ""
 }
+
+variable "pip_name" {
+  description = "(Optional) Name of public ip. If it is set, the 'prefix' variable will be ignored."
+  type        = string
+  default     = ""
+}

--- a/variables.tf
+++ b/variables.tf
@@ -100,3 +100,9 @@ variable "pip_sku" {
   type        = string
   default     = "Basic"
 }
+
+variable "name" {
+  description = "(Optional) Name of the load balancer. If it is set, the 'prefix' variable will be ignored."
+  type        = string
+  default     = ""
+}


### PR DESCRIPTION
<!---
Please add this into the test of test/fixture, format the changes by "terraform fmt", and test it by run the following:
```sh
$ docker build --build-arg BUILD_ARM_SUBSCRIPTION_ID=$ARM_SUBSCRIPTION_ID --build-arg BUILD_ARM_CLIENT_ID=$ARM_CLIENT_ID --build-arg BUILD_ARM_CLIENT_SECRET=$ARM_CLIENT_SECRET --build-arg BUILD_ARM_TENANT_ID=$ARM_TENANT_ID -t azure-loadbalancer .
$ docker run --rm azure-loadbalancer /bin/bash -c "bundle install && rake full"
```
Please add this into the example usage of README.md and format the changes by "terrafmt fmt README.md". Please intall "terrafmt" by [install terrafmt](hterrt#install).
--->

Fixes #000 

Changes proposed in the pull request:

Adds a new variable "name" that overrides "prefix". When this new variable is set the name of the load balancer will be set to match the variable value. It enables custom resource naming including the recommended Azure naming convention (https://docs.microsoft.com/en-us/azure/cloud-adoption-framework/ready/azure-best-practices/resource-abbreviations). The name of the private ip will also change to "pip-${name}"

Also includes https://github.com/Azure/terraform-azurerm-loadbalancer/pull/34


