### PR TITLE
Added new variables to set subnet by name

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -4,22 +4,16 @@ data "azurerm_resource_group" "azlb" {
 }
 
 locals {
-  lb_name  = var.name != "" ? var.name : format("%s-lb", var.prefix)
-  pip_name = var.pip_name != "" ? var.pip_name : format("%s-publicIP", var.prefix)
-}
-
-data "azurerm_virtual_network" "vnet" {
-  count = var.frontend_vnet_name != null ? 1 : 0
-
-  name                = var.frontend_vnet_name
-  resource_group_name = data.azurerm_resource_group.azlb.name
+  lb_name         = var.name != "" ? var.name : format("%s-lb", var.prefix)
+  pip_name        = var.pip_name != "" ? var.pip_name : format("%s-publicIP", var.prefix)
+  vnet_id_by_name = length(data.azurerm_subnet.snet) == 1 ? element(data.azurerm_subnet.snet.*.id, 0) : ""
 }
 
 data "azurerm_subnet" "snet" {
-  count = var.frontend_subnet_name != null ? 1 : 0
+  count = var.frontend_subnet_name != "" ? 1 : 0
 
   name                 = var.frontend_subnet_name
-  virtual_network_name = data.azurerm_virtual_network.vnet[0].name
+  virtual_network_name = var.frontend_vnet_name
   resource_group_name  = data.azurerm_resource_group.azlb.name
 }
 
@@ -44,7 +38,7 @@ resource "azurerm_lb" "azlb" {
   frontend_ip_configuration {
     name                          = var.frontend_name
     public_ip_address_id          = var.type == "public" ? join("", azurerm_public_ip.azlb.*.id) : ""
-    subnet_id                     = var.frontend_subnet_id != "" ? var.frontend_subnet_id : data.azurerm_subnet.snet[0].id
+    subnet_id                     = var.frontend_subnet_id != "" ? var.frontend_subnet_id : local.vnet_id_by_name
     private_ip_address            = var.frontend_private_ip_address
     private_ip_address_allocation = var.frontend_private_ip_address_allocation
   }

--- a/test/fixture/main.tf
+++ b/test/fixture/main.tf
@@ -12,10 +12,12 @@ resource "azurerm_resource_group" "test" {
 }
 
 module "mylb" {
-  source                                 = "../.."
-  resource_group_name                    = azurerm_resource_group.test.name
-  type                                   = "private"
-  frontend_subnet_id                     = module.network.vnet_subnets[0]
+  source              = "../.."
+  resource_group_name = azurerm_resource_group.test.name
+  type                = "private"
+  #frontend_subnet_id                     = module.network.vnet_subnets[0]
+  frontend_vnet_name                     = "acctvnet"
+  frontend_subnet_name                   = "subnet1"
   frontend_private_ip_address_allocation = "Static"
   frontend_private_ip_address            = "10.0.1.6"
   lb_sku                                 = "Standard"
@@ -42,7 +44,7 @@ module "mylb" {
     source      = "terraform"
   }
 
-  depends_on = [azurerm_resource_group.test]
+  depends_on = [module.network]
 }
 
 module "network" {
@@ -50,6 +52,7 @@ module "network" {
   resource_group_name = azurerm_resource_group.test.name
   address_space       = "10.0.0.0/16"
   subnet_prefixes     = ["10.0.1.0/24", "10.0.2.0/24", "10.0.3.0/24"]
+  vnet_name           = "acctvnet"
   subnet_names        = ["subnet1", "subnet2", "subnet3"]
 
   tags = {

--- a/variables.tf
+++ b/variables.tf
@@ -112,3 +112,15 @@ variable "pip_name" {
   type        = string
   default     = ""
 }
+
+variable "frontend_vnet_name" {
+  description = "(Optional) Frontend virtual network name to use when in private mode. Ignored if frontend_subnet_id is set."
+  type        = string
+  default     = ""
+}
+
+variable "frontend_subnet_name" {
+  description = "(Optional) Frontend subnet name to use when in private mode. Ignored if frontend_subnet_id is set."
+  type        = string
+  default     = ""
+}


### PR DESCRIPTION
<!---
Please add this into the test of test/fixture, format the changes by "terraform fmt", and test it by run the following:
```sh
$ docker build --build-arg BUILD_ARM_SUBSCRIPTION_ID=$ARM_SUBSCRIPTION_ID --build-arg BUILD_ARM_CLIENT_ID=$ARM_CLIENT_ID --build-arg BUILD_ARM_CLIENT_SECRET=$ARM_CLIENT_SECRET --build-arg BUILD_ARM_TENANT_ID=$ARM_TENANT_ID -t azure-loadbalancer .
$ docker run --rm azure-loadbalancer /bin/bash -c "bundle install && rake full"
```
Please add this into the example usage of README.md and format the changes by "terrafmt fmt README.md". Please intall "terrafmt" by [install terrafmt](https://github.com/katbyte/terrafmt#install).
--->

Changes proposed in the pull request:

New input variables added:
- frontend_vnet_name
- frontend_subnet_name
These new variables are ignored if frontend_subnet_id is set.


