### PR TITLE
new variable 'disable_outbound_snat' added

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -35,8 +35,8 @@ resource "azurerm_lb" "azlb" {
 }
 
 resource "azurerm_lb_backend_address_pool" "azlb" {
-  name                = "BackEndAddressPool"
-  loadbalancer_id     = azurerm_lb.azlb.id
+  name            = "BackEndAddressPool"
+  loadbalancer_id = azurerm_lb.azlb.id
 }
 
 resource "azurerm_lb_nat_rule" "azlb" {
@@ -75,4 +75,5 @@ resource "azurerm_lb_rule" "azlb" {
   backend_address_pool_id        = azurerm_lb_backend_address_pool.azlb.id
   idle_timeout_in_minutes        = 5
   probe_id                       = element(azurerm_lb_probe.azlb.*.id, count.index)
+  disable_outbound_snat          = var.disable_outbound_snat
 }

--- a/test/fixture/main.tf
+++ b/test/fixture/main.tf
@@ -22,6 +22,7 @@ module "mylb" {
   pip_sku                                = "Standard"
   name                                   = "lb-aztest"
   pip_name                               = "pip-aztest"
+  disable_outbound_snat                  = true
 
   remote_port = {
     ssh = ["Tcp", "22"]

--- a/variables.tf
+++ b/variables.tf
@@ -112,3 +112,9 @@ variable "pip_name" {
   type        = string
   default     = ""
 }
+
+variable "disable_outbound_snat" {
+  description = "(Optional) Is snat enabled for this Load Balancer Rule?."
+  type        = bool
+  default     = false
+}


### PR DESCRIPTION
<!---
Please add this into the test of test/fixture, format the changes by "terraform fmt", and test it by run the following:
```sh
$ docker build --build-arg BUILD_ARM_SUBSCRIPTION_ID=$ARM_SUBSCRIPTION_ID --build-arg BUILD_ARM_CLIENT_ID=$ARM_CLIENT_ID --build-arg BUILD_ARM_CLIENT_SECRET=$ARM_CLIENT_SECRET --build-arg BUILD_ARM_TENANT_ID=$ARM_TENANT_ID -t azure-loadbalancer .
$ docker run --rm azure-loadbalancer /bin/bash -c "bundle install && rake full"
```
Please add this into the example usage of README.md and format the changes by "terrafmt fmt README.md". Please intall "terrafmt" by [install terrafmt](https://github.com/katbyte/terrafmt#install).
--->

Changes proposed in the pull request:
- adds a new optional variable "disable_outbound_snat" to enable/disable load balancer rule SNAT. The default value is "false"
