### PR TITLE
Add more variables for public ip customization

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -15,6 +15,9 @@ resource "azurerm_public_ip" "azlb" {
   location            = coalesce(var.location, data.azurerm_resource_group.azlb.location)
   allocation_method   = var.allocation_method
   sku                 = var.pip_sku
+  availability_zone   = var.pip_availability_zone
+  domain_name_label   = var.pip_domain_name_label
+  reverse_fqdn        = var.pip_reverse_fqdn
   tags                = var.tags
 }
 
@@ -35,8 +38,8 @@ resource "azurerm_lb" "azlb" {
 }
 
 resource "azurerm_lb_backend_address_pool" "azlb" {
-  name                = "BackEndAddressPool"
-  loadbalancer_id     = azurerm_lb.azlb.id
+  name            = "BackEndAddressPool"
+  loadbalancer_id = azurerm_lb.azlb.id
 }
 
 resource "azurerm_lb_nat_rule" "azlb" {

--- a/outputs.tf
+++ b/outputs.tf
@@ -38,6 +38,11 @@ output "azurerm_public_ip_address" {
   value       = azurerm_public_ip.azlb.*.ip_address
 }
 
+output "azurerm_public_ip_fqdn" {
+  description = "the fqdn for the azurerm_lb_public_ip resource"
+  value       = azurerm_public_ip.azlb.*.fqdn
+}
+
 output "azurerm_lb_backend_address_pool_id" {
   description = "the id for the azurerm_lb_backend_address_pool resource"
   value       = azurerm_lb_backend_address_pool.azlb.id

--- a/variables.tf
+++ b/variables.tf
@@ -112,3 +112,21 @@ variable "pip_name" {
   type        = string
   default     = ""
 }
+
+variable "pip_availability_zone" {
+  description = "(Optional) The availability zone to allocate the Public IP in."
+  type        = string
+  default     = ""
+}
+
+variable "pip_domain_name_label" {
+  description = "(Optional) Label for the Domain Name. Will be used to make up the FQDN. If a domain name label is specified, an A DNS record is created for the public IP in the Microsoft Azure DNS system."
+  type        = string
+  default     = ""
+}
+
+variable "pip_reverse_fqdn" {
+  description = "(Optional) A fully qualified domain name that resolves to this public IP address. If the reverseFqdn is specified, then a PTR DNS record is created pointing from the IP address in the in-addr.arpa domain to the reverse FQDN."
+  type        = string
+  default     = ""
+}


### PR DESCRIPTION
- pip_availability_zone
- pip_domain_name_label
- pip_reverse_fqdn

<!---
Please add this into the test of test/fixture, format the changes by "terraform fmt", and test it by run the following:
```sh
$ docker build --build-arg BUILD_ARM_SUBSCRIPTION_ID=$ARM_SUBSCRIPTION_ID --build-arg BUILD_ARM_CLIENT_ID=$ARM_CLIENT_ID --build-arg BUILD_ARM_CLIENT_SECRET=$ARM_CLIENT_SECRET --build-arg BUILD_ARM_TENANT_ID=$ARM_TENANT_ID -t azure-loadbalancer .
$ docker run --rm azure-loadbalancer /bin/bash -c "bundle install && rake full"
```
Please add this into the example usage of README.md and format the changes by "terrafmt fmt README.md". Please intall "terrafmt" by [install terrafmt](https://github.com/katbyte/terrafmt#install).
--->

Changes proposed in the pull request:

Add needed variables to create a fqdn for the public ip, thus we can access the load balancer with a dns.
