### PR TITLE
fix: update backend_address_pool_id to ids with a list element

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -72,7 +72,7 @@ resource "azurerm_lb_rule" "azlb" {
   backend_port                   = element(var.lb_port[element(keys(var.lb_port), count.index)], 2)
   frontend_ip_configuration_name = var.frontend_name
   enable_floating_ip             = false
-  backend_address_pool_id        = azurerm_lb_backend_address_pool.azlb.id
+  backend_address_pool_ids       = [ azurerm_lb_backend_address_pool.azlb.id ]
   idle_timeout_in_minutes        = 5
   probe_id                       = element(azurerm_lb_probe.azlb.*.id, count.index)
 }


### PR DESCRIPTION
<!---
Please add this into the test of test/fixture, format the changes by "terraform fmt", and test it by run the following:
```sh
$ docker build --build-arg BUILD_ARM_SUBSCRIPTION_ID=$ARM_SUBSCRIPTION_ID --build-arg BUILD_ARM_CLIENT_ID=$ARM_CLIENT_ID --build-arg BUILD_ARM_CLIENT_SECRET=$ARM_CLIENT_SECRET --build-arg BUILD_ARM_TENANT_ID=$ARM_TENANT_ID -t azure-loadbalancer .
$ docker run --rm azure-loadbalancer /bin/bash -c "bundle install && rake full"
```
Please add this into the example usage of README.md and format the changes by "terrafmt fmt README.md". Please intall "terrafmt" by [install terrafmt](https://github.com/katbyte/terrafmt#install).
--->

Fixes #42 

Changes proposed in the pull request:
1. Update the azurerm_lb_rule with the new property.


