### PR TITLE
Fix unsupported parameter and options about lb-rule

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -70,7 +70,7 @@ resource "azurerm_lb_rule" "azlb" {
   backend_port                   = element(var.lb_port[element(keys(var.lb_port), count.index)], 2)
   frontend_ip_configuration_name = var.frontend_name
   enable_floating_ip             = false
-  backend_address_pool_id        = azurerm_lb_backend_address_pool.azlb.id
+  backend_address_pool_ids       = [azurerm_lb_backend_address_pool.azlb.id]
   idle_timeout_in_minutes        = 5
   probe_id                       = element(azurerm_lb_probe.azlb.*.id, count.index)
 }

--- a/main.tf
+++ b/main.tf
@@ -44,7 +44,7 @@ resource "azurerm_lb_nat_rule" "azlb" {
   name                           = "VM-${count.index}"
   resource_group_name            = data.azurerm_resource_group.azlb.name
   loadbalancer_id                = azurerm_lb.azlb.id
-  protocol                       = "tcp"
+  protocol                       = "Tcp"
   frontend_port                  = "5000${count.index + 1}"
   backend_port                   = element(var.remote_port[element(keys(var.remote_port), count.index)], 1)
   frontend_ip_configuration_name = var.frontend_name

--- a/main.tf
+++ b/main.tf
@@ -53,7 +53,6 @@ resource "azurerm_lb_nat_rule" "azlb" {
 resource "azurerm_lb_probe" "azlb" {
   count               = length(var.lb_probe)
   name                = element(keys(var.lb_probe), count.index)
-  resource_group_name = data.azurerm_resource_group.azlb.name
   loadbalancer_id     = azurerm_lb.azlb.id
   protocol            = element(var.lb_probe[element(keys(var.lb_probe), count.index)], 0)
   port                = element(var.lb_probe[element(keys(var.lb_probe), count.index)], 1)
@@ -65,7 +64,6 @@ resource "azurerm_lb_probe" "azlb" {
 resource "azurerm_lb_rule" "azlb" {
   count                          = length(var.lb_port)
   name                           = element(keys(var.lb_port), count.index)
-  resource_group_name            = data.azurerm_resource_group.azlb.name
   loadbalancer_id                = azurerm_lb.azlb.id
   protocol                       = element(var.lb_port[element(keys(var.lb_port), count.index)], 1)
   frontend_port                  = element(var.lb_port[element(keys(var.lb_port), count.index)], 0)


### PR DESCRIPTION
Fixes #46 

Changes proposed in the pull request:

- Update "tcp" to "Tcp" on azurerm_lb_nat_rule
- Remove unneeded "resource_group_name" on  azurerm_lb_probe
- Udpate "backend_address_pool_id" on azurerm_lb_rule to have a list of one element.


