### PR TITLE
Capture the iterator variable to avoid concurrent test error

### DIFF
--- a/test/e2e/terraform_e2e_test.go
+++ b/test/e2e/terraform_e2e_test.go
@@ -14,8 +14,9 @@ func TestExmaples(t *testing.T) {
 	}
 
 	for _, v := range testPaths {
-		t.Run(v, func(t *testing.T) {
-			test_helper.RunE2ETest(t, "../../", v, terraform.Options{
+		p := v
+		t.Run(p, func(t *testing.T) {
+			test_helper.RunE2ETest(t, "../../", p, terraform.Options{
 				Upgrade: true,
 			}, func(t *testing.T, output test_helper.TerraformOutput) {})
 		})

--- a/test/upgrade/terraform_upgrade_test.go
+++ b/test/upgrade/terraform_upgrade_test.go
@@ -18,10 +18,12 @@ func TestExamplesUpgrade(t *testing.T) {
 	}
 	examples := []string{
 		"examples/startup",
+		"examples/set_subnet_by_name",
 	}
 	for _, example := range examples {
-		t.Run(example, func(t *testing.T) {
-			test_helper.ModuleUpgradeTest(t, "Azure", "terraform-azurerm-loadbalancer", example, currentRoot, terraform.Options{
+		e := example
+		t.Run(e, func(t *testing.T) {
+			test_helper.ModuleUpgradeTest(t, "Azure", "terraform-azurerm-loadbalancer", e, currentRoot, terraform.Options{
 				Upgrade: true,
 			}, currentMajorVersion)
 		})


### PR DESCRIPTION
## Describe your changes

We have a classic `foreach` error in our go test code, it would cause randomly error when we try to execute tests concurrently, this pull request capture the iterator variable into a local variable to avoid such error.

## Issue number

## Checklist before requesting a review
- [ ] The pr title can be used to describe what this pr did in `CHANGELOG.md` file
- [ ] I have executed pre-commit on my machine
- [ ] I have passed pr-check on my machine

Thanks for your cooperation!

